### PR TITLE
Use serde_json to interpret the JSON response

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,4 +11,6 @@ license = "MIT"
 
 [dependencies]
 reqwest = "0.3"
-json = "0.11"
+serde = "0.8"
+serde_derive = "0.8"
+serde_json = "0.8"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,80 +1,32 @@
+#[macro_use]
+extern crate serde_derive;
+
 extern crate reqwest;
-extern crate json;
+extern crate serde_json;
 
-use std::io::Read;
-use json::JsonValue;
-
-#[derive(Debug)]
-pub enum Error {
-    Network(reqwest::Error),
-    Json(json::Error),
-    Decoding(&'static str),
-}
-
-#[derive(Debug)]
+#[derive(Deserialize, Debug)]
 pub struct Crate {
     pub name: String,
+    #[serde(rename = "max_version")]
     pub version: String,
     pub description: Option<String>,
     pub license: Option<String>,
+    #[serde(rename = "homepage")]
     pub homepage_url: Option<String>,
+    #[serde(rename = "repository")]
     pub repository_url: Option<String>,
+    #[serde(rename = "documentation")]
     pub documentation_url: Option<String>,
 }
 
-impl Crate {
-    pub fn from_json(json: &JsonValue) -> Result<Crate, Error> {
-        let krate = Crate {
-            name: json_string(&json, "name")?,
-            version: json_string(&json, "max_version")?,
-            description: json_option_string(&json, "description"),
-            license: json_option_string(&json, "license"),
-            homepage_url: json_option_string(&json, "homepage"),
-            repository_url: json_option_string(&json, "repository"),
-            documentation_url: json_option_string(&json, "documentation"),
-        };
-
-        Ok(krate)
-    }
+/// Wrapper used by crates.io API.
+#[derive(Deserialize)]
+struct Crates {
+    crates: Vec<Crate>,
 }
 
-fn json_option_string(json: &JsonValue, name: &'static str) -> Option<String> {
-    let str = match json[name].as_str() {
-        Some(str) => str,
-        None => return None,
-    };
-    Some(String::from(str))
-}
-
-fn json_string(json: &JsonValue, name: &'static str) -> Result<String, Error> {
-    // not sure if this is a stupid idea or not
-    let str = json[name].as_str().ok_or_else(|| Error::Decoding(name))?;
-    Ok(String::from(str))
-}
-
-pub fn search(query: &str) -> Result<Vec<Crate>, Error> {
+pub fn search(query: &str) -> Result<Vec<Crate>, reqwest::Error> {
     let url = format!("https://crates.io/api/v1/crates?page=1&per_page=100&q={}",
                       query);
-    let mut res = reqwest::get(&url).unwrap();
-
-    let mut response = String::new();
-    let _ = res.read_to_string(&mut response);
-
-    let json = match json::parse(&response) {
-        Ok(val) => val,
-        Err(err) => return Err(Error::Json(err)),
-    };
-
-    let json = match json["crates"] {
-        JsonValue::Array(ref arr) => arr,
-        _ => return Err(Error::Decoding("Found non-array-value in `crates`.")),
-    };
-
-    let mut crates: Vec<Crate> = Vec::new();
-    for json_val in json {
-        let krate = Crate::from_json(&json_val)?;
-        crates.push(krate);
-    }
-
-    Ok(crates)
+    reqwest::get(&url)?.json().map(|response: Crates| response.crates)
 }


### PR DESCRIPTION
This eliminates all the manual logic of pulling out pieces of the JSON. All of that can be done programmatically and is already built into reqwests.

The serde_derive crate requires a nightly or beta compiler right now but it will be stable in the Rust 1.15 release in less than 2 weeks so this is a good time to migrate.